### PR TITLE
do not append .svg to size badge

### DIFF
--- a/features/size.feature
+++ b/features/size.feature
@@ -12,7 +12,7 @@ Scenario: Include 'size' badge
   [![Dependency Status](http://img.shields.io/gemnasium/doge/wow.svg)](https://gemnasium.com/doge/wow)
   [![Coverage Status](http://img.shields.io/coveralls/doge/wow.svg)](https://coveralls.io/r/doge/wow)
   [![Code Climate](http://img.shields.io/codeclimate/github/doge/wow.svg)](https://codeclimate.com/github/doge/wow)
-  [![Repo Size](http://reposs.herokuapp.com/?path=doge/wow.svg)](https://github.com/doge/wow)
+  [![Repo Size](http://reposs.herokuapp.com/?path=doge/wow)](https://github.com/doge/wow)
   [![Gem Version](http://img.shields.io/gem/v/suchgem.svg)](https://rubygems.org/gems/suchgem)
   [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
   [![Badges](http://img.shields.io/:badges-8/8-ff6799.svg)](https://github.com/badges/badgerbadgerbadger)

--- a/lib/badger/badge.rb
+++ b/lib/badger/badge.rb
@@ -1,9 +1,15 @@
 module Badger
   def Badger.badge text, badge_url, target_url
-    badge_url = "%s.%s" % [
+    if text == "Repo Size"
+      badge_url = "%s" % [
+      badge_url
+    ]
+    else
+      badge_url = "%s.%s" % [
       badge_url,
       Config.instance.config['badge_type']
     ]
+    end
 
     badge_style = Config.instance.config['badge_style']
     badge_url = "%s?style=%s" % [

--- a/spec/size_spec.rb
+++ b/spec/size_spec.rb
@@ -13,7 +13,7 @@ module Badger
     context 'size badge' do
       it 'has a size badge' do
         @badger.add 'size'
-        expect(@badger[0]).to eq '[![Repo Size](http://reposs.herokuapp.com/?path=doge/wow.svg)](https://github.com/doge/wow)'
+        expect(@badger[0]).to eq '[![Repo Size](http://reposs.herokuapp.com/?path=doge/wow)](https://github.com/doge/wow)'
       end
     end
   end


### PR DESCRIPTION
Your work closes #66 and this deals with size badge not requiring `".svg"` in badge url. Appending it actually results in "NAN" being displayed in badge instead of size.

Sorry I didn't catch it in your previous pull request.