### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-##Copyright (c) 2013 Sam Pikesley
+## Copyright (c) 2013 Sam Pikesley
 
-#MIT License
+# MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/features/support/fixtures/licenses/mit.md
+++ b/features/support/fixtures/licenses/mit.md
@@ -1,6 +1,6 @@
-##Copyright (c) 2013 Sam Pikesley
+## Copyright (c) 2013 Sam Pikesley
 
-#MIT License
+# MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
