### PR TITLE
Support for travis-ci.com

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,12 @@ travis:
   url_path:     travis-ci.org
   badge_slug:   travis
 
+travis-com:
+  alt_text:     Build Status
+  scheme:       https
+  url_path:     travis-ci.com
+  badge_slug:   travis/com
+
 coveralls:
   alt_text:     Coverage Status
   url_path:     coveralls.io/r

--- a/lib/badger/cli.rb
+++ b/lib/badger/cli.rb
@@ -14,6 +14,7 @@ module Badger
     long_desc File.read File.join File.dirname( __FILE__), '..', '..', 'DESC.md'
     method_option :png, :type => :boolean, :default => false, :desc => 'Generate PNG badges instead of the default SVG (because sometimes Github does caching things)'
     method_option :pulls, :type => :boolean, :default => false, :desc => 'Generate Github pull-request and issue-count badges'
+    method_option :travis_com, :type => :boolean, :default => false, :desc => 'Description'
     method_option :size, :type => :boolean, :default => false, :desc => 'Generate repo size badge'
     method_option :dci, :type => :boolean, :default => false, :desc => 'Include a Dependency CI badge (experimental)'
     method_option :style, :type => :string, :default => 'flat-square', :desc => "Choose a different badge style (currently supported: #{Config.instance.config['valid_styles'].join ', '})"
@@ -25,7 +26,8 @@ module Badger
 
       @badger.style options[:style] if options[:style]
 
-      @badger.add 'travis' if Badger.has_travis? dir
+      @badger.add 'travis' if Badger.has_travis? dir and not options[:travis_com]
+      @badger.add 'travis-com' if Badger.has_travis? dir and options[:travis_com]
       @badger.add 'gemnasium' if Badger.has_gemfile? dir
       @badger.dependencyci if options[:dci]
       @badger.add 'coveralls' if Badger.has_coveralls? dir

--- a/lib/badger/cli.rb
+++ b/lib/badger/cli.rb
@@ -14,7 +14,7 @@ module Badger
     long_desc File.read File.join File.dirname( __FILE__), '..', '..', 'DESC.md'
     method_option :png, :type => :boolean, :default => false, :desc => 'Generate PNG badges instead of the default SVG (because sometimes Github does caching things)'
     method_option :pulls, :type => :boolean, :default => false, :desc => 'Generate Github pull-request and issue-count badges'
-    method_option :travis_com, :type => :boolean, :default => false, :desc => 'Description'
+    method_option :travis_com, :type => :boolean, :default => false, :desc => 'Use the new travis-ci domain (travis-ci.com instead of travis-ci.org)'
     method_option :size, :type => :boolean, :default => false, :desc => 'Generate repo size badge'
     method_option :dci, :type => :boolean, :default => false, :desc => 'Include a Dependency CI badge (experimental)'
     method_option :style, :type => :string, :default => 'flat-square', :desc => "Choose a different badge style (currently supported: #{Config.instance.config['valid_styles'].join ', '})"


### PR DESCRIPTION
Travis-CI is switching to a new domain `travis-ci.com`, this commit adds support for this domain with a CLI option.